### PR TITLE
configurable scope and record channels

### DIFF
--- a/libraries/REBUS/lib.metadata
+++ b/libraries/REBUS/lib.metadata
@@ -1,5 +1,5 @@
 name=REBUS
-version=0.0.1
+version=0.0.2
 author=Eleonora Maria Irene Oreggia, Claude Heiland-Allen
 maintainer=Eleonora Maria Irene Oreggia, Claude Heiland-Allen
 description=REBUS - Electromagnetic Interactions.


### PR DESCRIPTION
Make scope and record channels configurable, by defining things before including the REBUS.h library.  For example:

```c++
#define SCOPE 1
#define SCOPE_CHANNELS 2
#define SCOPE_CHANNEL_1 GAIN
#define SCOPE_CHANNEL_2 PHASE

#define RECORD 1
#define RECORD_CHANNELS 2
#define RECORD_CHANNEL_1 OUT_LEFT
#define RECORD_CHANNEL_2 OUT_RIGHT
```

Library version bumped to 0.0.2 for the new features.

Defaults remain the same (6 channels for each, with scope enabled and record disabled).
